### PR TITLE
feat(ui): implement Memory Cycles UI for Filage and Lecture

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -2857,4 +2857,147 @@ export type {
 	AlertsResponse
 };
 
+// ============================================================================
+// MEMORY CYCLES TYPES (Filage & Lecture)
+// ============================================================================
+
+interface FilageLecture {
+	note_id: string;
+	note_title: string;
+	note_type: string;
+	priority: number;
+	reason: string;
+	quality_score: number | null;
+	questions_pending: boolean;
+	questions_count: number;
+	related_event_id?: string;
+}
+
+interface Filage {
+	date: string;
+	generated_at: string;
+	lectures: FilageLecture[];
+	total_lectures: number;
+	events_today: number;
+	notes_with_questions: number;
+}
+
+interface LectureSession {
+	session_id: string;
+	note_id: string;
+	note_title: string;
+	note_content: string;
+	started_at: string;
+	quality_score: number | null;
+	questions: string[];
+}
+
+interface LectureResult {
+	note_id: string;
+	quality_rating: number;
+	next_lecture: string;
+	interval_hours: number;
+	answers_recorded: number;
+	questions_remaining: number;
+	success: boolean;
+}
+
+interface PendingQuestion {
+	question_id: string;
+	note_id: string;
+	note_title: string;
+	question_text: string;
+	created_at: string;
+	answered: boolean;
+	answer?: string;
+}
+
+interface QuestionsListResponse {
+	questions: PendingQuestion[];
+	total: number;
+	by_note: Record<string, number>;
+}
+
+interface LectureStats {
+	note_id: string;
+	total_lectures: number;
+	average_quality: number;
+	last_lecture: string | null;
+	next_lecture: string | null;
+	easiness_factor: number;
+	interval_hours: number;
+}
+
+// ============================================================================
+// MEMORY CYCLES API FUNCTIONS
+// ============================================================================
+
+/**
+ * Get daily filage (morning briefing) with prioritized lectures
+ */
+export async function getFilage(maxLectures = 20): Promise<Filage> {
+	return fetchApi<Filage>(`/briefing/filage?max_lectures=${maxLectures}`);
+}
+
+/**
+ * Start a lecture session for a specific note
+ */
+export async function startLecture(noteId: string): Promise<LectureSession> {
+	return fetchApi<LectureSession>(`/briefing/lecture/${encodeURIComponent(noteId)}/start`, {
+		method: 'POST'
+	});
+}
+
+/**
+ * Complete a lecture session with quality rating and optional question answers
+ */
+export async function completeLecture(
+	noteId: string,
+	quality: number,
+	answers?: Record<string, string>
+): Promise<LectureResult> {
+	return fetchApi<LectureResult>(`/briefing/lecture/${encodeURIComponent(noteId)}/complete`, {
+		method: 'POST',
+		body: JSON.stringify({ quality, answers })
+	});
+}
+
+/**
+ * Get lecture stats for a specific note
+ */
+export async function getLectureStats(noteId: string): Promise<LectureStats> {
+	return fetchApi<LectureStats>(`/notes/${encodeURIComponent(noteId)}/lecture-stats`);
+}
+
+/**
+ * Get list of pending questions across all notes
+ */
+export async function getPendingQuestions(limit = 50): Promise<QuestionsListResponse> {
+	return fetchApi<QuestionsListResponse>(`/notes/questions/pending?limit=${limit}`);
+}
+
+/**
+ * Answer a pending question
+ */
+export async function answerPendingQuestion(
+	questionId: string,
+	answer: string
+): Promise<{ success: boolean }> {
+	return fetchApi<{ success: boolean }>(`/notes/questions/${encodeURIComponent(questionId)}/answer`, {
+		method: 'POST',
+		body: JSON.stringify({ answer })
+	});
+}
+
 export { ApiError };
+
+export type {
+	// Memory Cycles types
+	FilageLecture,
+	Filage,
+	LectureSession,
+	LectureResult,
+	PendingQuestion,
+	QuestionsListResponse,
+	LectureStats
+};

--- a/web/src/lib/api/types/memory-cycles.ts
+++ b/web/src/lib/api/types/memory-cycles.ts
@@ -1,0 +1,168 @@
+/**
+ * Memory Cycles Types
+ * Types for Filage (daily briefing) and Lecture (review sessions)
+ */
+
+// ============================================================================
+// FILAGE TYPES (Briefing matinal)
+// ============================================================================
+
+export interface FilageLecture {
+	note_id: string;
+	note_title: string;
+	note_type: string;
+	priority: number;
+	reason: string; // "Questions en attente", "Lié à: {event}", "SM-2 due", "Améliorée"
+	quality_score: number | null;
+	questions_pending: boolean;
+	questions_count: number;
+	related_event_id?: string;
+}
+
+export interface Filage {
+	date: string;
+	generated_at: string;
+	lectures: FilageLecture[];
+	total_lectures: number;
+	events_today: number;
+	notes_with_questions: number;
+}
+
+// ============================================================================
+// LECTURE SESSION TYPES (Review sessions)
+// ============================================================================
+
+export interface LectureSession {
+	session_id: string;
+	note_id: string;
+	note_title: string;
+	note_content: string;
+	started_at: string;
+	quality_score: number | null;
+	questions: string[];
+}
+
+export interface LectureResult {
+	note_id: string;
+	quality_rating: number;
+	next_lecture: string;
+	interval_hours: number;
+	answers_recorded: number;
+	questions_remaining: number;
+	success: boolean;
+}
+
+// ============================================================================
+// QUESTIONS TYPES
+// ============================================================================
+
+export interface PendingQuestion {
+	question_id: string;
+	note_id: string;
+	note_title: string;
+	question_text: string;
+	created_at: string;
+	answered: boolean;
+	answer?: string;
+}
+
+export interface QuestionsListResponse {
+	questions: PendingQuestion[];
+	total: number;
+	by_note: Record<string, number>;
+}
+
+// ============================================================================
+// RETOUCHE (AI Improvements) TYPES
+// ============================================================================
+
+export interface RetoucheEntry {
+	retouche_id: string;
+	note_id: string;
+	timestamp: string;
+	model_used: 'haiku' | 'sonnet' | 'opus';
+	quality_before: number | null;
+	quality_after: number | null;
+	changes_summary: string;
+	confidence: number;
+}
+
+export interface RetoucheTimeline {
+	note_id: string;
+	retouches: RetoucheEntry[];
+	total_improvements: number;
+	quality_trend: number[]; // Array of quality scores over time
+}
+
+// ============================================================================
+// GAMIFICATION TYPES
+// ============================================================================
+
+export interface StreakInfo {
+	current_streak: number;
+	longest_streak: number;
+	last_review_date: string | null;
+	streak_maintained: boolean;
+}
+
+export interface ReviewBadge {
+	badge_id: string;
+	name: string;
+	description: string;
+	icon: string;
+	earned_at: string | null;
+	progress: number; // 0-100
+}
+
+export interface GamificationStats {
+	streak: StreakInfo;
+	badges: ReviewBadge[];
+	total_reviews: number;
+	reviews_this_week: number;
+	xp_total: number;
+	level: number;
+}
+
+// ============================================================================
+// LECTURE STATS TYPES
+// ============================================================================
+
+export interface LectureStats {
+	note_id: string;
+	total_lectures: number;
+	average_quality: number;
+	last_lecture: string | null;
+	next_lecture: string | null;
+	easiness_factor: number;
+	interval_hours: number;
+}
+
+// ============================================================================
+// REASON CATEGORIES
+// ============================================================================
+
+export type FilageReasonCategory =
+	| 'questions_pending'
+	| 'event_related'
+	| 'sm2_due'
+	| 'recently_improved'
+	| 'low_quality'
+	| 'manual';
+
+export const REASON_LABELS: Record<FilageReasonCategory, string> = {
+	questions_pending: 'Questions en attente',
+	event_related: 'Lié aux événements',
+	sm2_due: 'Révision SM-2 due',
+	recently_improved: 'Récemment améliorée',
+	low_quality: 'Qualité à améliorer',
+	manual: 'Ajouté manuellement'
+};
+
+export const REASON_ICONS: Record<FilageReasonCategory, string> = {
+	questions_pending: '❓',
+	event_related: '📅',
+	sm2_due: '📚',
+	recently_improved: '✨',
+	low_quality: '⚠️',
+	manual: '📌'
+};

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { openCommandPalette } from '$lib/stores';
+	import { memoryCyclesStore } from '$lib/stores/memory-cycles.svelte';
 
 	interface NavItem {
 		href: string;
 		label: string;
 		icon: string;
+		badge?: () => number;
 	}
 
 	const navItems: NavItem[] = [
 		{ href: '/', label: 'Matinée', icon: '☀️' },
 		{ href: '/peripeties', label: 'Péripéties', icon: '🎪' },
 		{ href: '/drafts', label: 'Brouillons', icon: '✏️' },
-		{ href: '/memoires', label: 'Mémoires', icon: '📝' },
+		{ href: '/memoires', label: 'Mémoires', icon: '📝', badge: () => memoryCyclesStore.pendingQuestionsCount },
 		{ href: '/discussions', label: 'Conversations', icon: '💬' },
 		{ href: '/confessions', label: 'Confessions', icon: '📖' },
 		{ href: '/valets', label: 'Valets', icon: '🎭' },
@@ -91,6 +93,7 @@
 	<nav class="flex-1 p-2 space-y-1" aria-label="Navigation principale">
 		{#each navItems as item}
 			{@const active = isActive(item.href, $page.url.pathname)}
+			{@const badgeCount = item.badge ? item.badge() : 0}
 			<a
 				href={item.href}
 				aria-current={active ? 'page' : undefined}
@@ -102,13 +105,26 @@
 					? 'glass-subtle text-[var(--color-accent)] shadow-[inset_0_0_0_1px_var(--color-accent)]/20'
 					: 'text-[var(--color-text-secondary)] hover:bg-[var(--glass-subtle)] hover:text-[var(--color-text-primary)]'}"
 			>
-				<span class="text-lg flex-shrink-0 w-6 text-center" aria-hidden="true">{item.icon}</span>
+				<span class="text-lg flex-shrink-0 w-6 text-center relative" aria-hidden="true">
+					{item.icon}
+					{#if badgeCount > 0 && !expanded}
+						<span class="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full"></span>
+					{/if}
+				</span>
 				{#if expanded}
-					<span class="font-medium text-sm whitespace-nowrap overflow-hidden">{item.label}</span>
+					<span class="font-medium text-sm whitespace-nowrap overflow-hidden flex-1">{item.label}</span>
+					{#if badgeCount > 0}
+						<span class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-500 font-medium">
+							{badgeCount}
+						</span>
+					{/if}
 				{:else}
 					<!-- Tooltip on hover when collapsed -->
 					<span class="absolute left-full ml-2 px-2 py-1 glass-prominent text-[var(--color-text-primary)] text-xs font-medium rounded-xl shadow-lg opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50">
 						{item.label}
+						{#if badgeCount > 0}
+							<span class="ml-1 text-red-500">({badgeCount})</span>
+						{/if}
 					</span>
 				{/if}
 			</a>

--- a/web/src/lib/components/memory/FilageLectureCard.svelte
+++ b/web/src/lib/components/memory/FilageLectureCard.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	/**
+	 * FilageLectureCard Component
+	 * Card for displaying a lecture in the filage list
+	 */
+	import type { FilageLecture } from '$lib/api/types/memory-cycles';
+	import { Card, Badge } from '$lib/components/ui';
+	import ConfidenceBar from '$lib/components/ui/ConfidenceBar.svelte';
+
+	interface Props {
+		lecture: FilageLecture;
+		onclick?: () => void;
+		selected?: boolean;
+	}
+
+	let { lecture, onclick, selected = false }: Props = $props();
+
+	// Note type icons
+	const typeIcons: Record<string, string> = {
+		personne: '👤',
+		organisation: '🏢',
+		projet: '📁',
+		concept: '💡',
+		lieu: '📍',
+		evenement: '📅',
+		produit: '📦',
+		default: '📝'
+	};
+
+	// Get quality color based on score
+	function getQualityColor(score: number | null): 'primary' | 'success' | 'warning' | 'danger' {
+		if (score === null) return 'primary';
+		if (score >= 80) return 'success';
+		if (score >= 60) return 'warning';
+		return 'danger';
+	}
+
+	const icon = $derived(typeIcons[lecture.note_type.toLowerCase()] || typeIcons.default);
+	const qualityColor = $derived(getQualityColor(lecture.quality_score));
+</script>
+
+<Card
+	variant={selected ? 'elevated' : 'glass-subtle'}
+	interactive
+	{onclick}
+	class="transition-all duration-200 {selected ? 'ring-2 ring-[var(--color-accent)]' : ''}"
+>
+	<div class="flex items-start gap-3">
+		<!-- Icon -->
+		<div class="flex-shrink-0 w-10 h-10 rounded-xl bg-[var(--glass-subtle)] flex items-center justify-center text-xl">
+			{icon}
+		</div>
+
+		<!-- Content -->
+		<div class="flex-1 min-w-0">
+			<!-- Title and badges -->
+			<div class="flex items-start justify-between gap-2">
+				<h3 class="font-medium text-[var(--color-text-primary)] truncate">
+					{lecture.note_title}
+				</h3>
+				{#if lecture.questions_pending}
+					<Badge class="flex-shrink-0 bg-red-500/10 text-red-500">
+						<span class="flex items-center gap-1">
+							<span>?</span>
+							<span class="text-xs">{lecture.questions_count}</span>
+						</span>
+					</Badge>
+				{/if}
+			</div>
+
+			<!-- Reason -->
+			<p class="text-sm text-[var(--color-text-secondary)] mt-0.5 line-clamp-1">
+				{lecture.reason}
+			</p>
+
+			<!-- Quality score bar -->
+			{#if lecture.quality_score !== null}
+				<div class="mt-2 flex items-center gap-2">
+					<span class="text-xs text-[var(--color-text-tertiary)]">Q:</span>
+					<div class="flex-1 max-w-[100px]">
+						<ConfidenceBar value={lecture.quality_score / 100} size="sm" showPercentage={false} />
+					</div>
+					<span class="text-xs font-medium text-[var(--color-text-secondary)]">
+						{lecture.quality_score}%
+					</span>
+				</div>
+			{/if}
+
+			<!-- Type badge -->
+			<div class="mt-2 flex items-center gap-2">
+				<Badge class="bg-[var(--glass-subtle)] text-[var(--color-text-tertiary)]">
+					{lecture.note_type}
+				</Badge>
+				{#if lecture.related_event_id}
+					<Badge class="bg-[var(--color-event-calendar)]/10 text-[var(--color-event-calendar)]">
+						Lié
+					</Badge>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Arrow indicator -->
+		<div class="flex-shrink-0 text-[var(--color-text-tertiary)]">
+			<span>→</span>
+		</div>
+	</div>
+</Card>

--- a/web/src/lib/components/memory/FilageProgressHeader.svelte
+++ b/web/src/lib/components/memory/FilageProgressHeader.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	/**
+	 * FilageProgressHeader Component
+	 * Sticky header with progress bar for filage page
+	 */
+	import ProgressRing from '$lib/components/ui/ProgressRing.svelte';
+
+	interface Props {
+		title: string;
+		current: number;
+		total: number;
+		onBack?: () => void;
+		onRefresh?: () => void;
+		loading?: boolean;
+	}
+
+	let { title, current, total, onBack, onRefresh, loading = false }: Props = $props();
+
+	const percent = $derived(total > 0 ? Math.round((current / total) * 100) : 0);
+</script>
+
+<header
+	class="sticky top-0 z-10 bg-[var(--color-bg-primary)]/80 backdrop-blur-md border-b border-[var(--glass-border-subtle)]"
+>
+	<div class="max-w-2xl mx-auto px-4 py-3">
+		<!-- Top row: navigation and actions -->
+		<div class="flex items-center justify-between mb-2">
+			{#if onBack}
+				<button
+					type="button"
+					onclick={onBack}
+					class="flex items-center gap-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors liquid-press"
+				>
+					<span>←</span>
+					<span class="text-sm">Retour</span>
+				</button>
+			{:else}
+				<div></div>
+			{/if}
+
+			<h1 class="text-base font-semibold text-[var(--color-text-primary)]">
+				{title}
+			</h1>
+
+			{#if onRefresh}
+				<button
+					type="button"
+					onclick={onRefresh}
+					disabled={loading}
+					class="p-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors liquid-press disabled:opacity-50"
+					aria-label="Rafraîchir"
+				>
+					<span class={loading ? 'animate-spin inline-block' : ''}>⟳</span>
+				</button>
+			{:else}
+				<div class="w-8"></div>
+			{/if}
+		</div>
+
+		<!-- Progress bar -->
+		<div class="flex items-center gap-3">
+			<div class="flex-1 h-2 bg-[var(--glass-subtle)] rounded-full overflow-hidden">
+				<div
+					class="h-full bg-[var(--color-accent)] transition-all duration-300 ease-out rounded-full"
+					style="width: {percent}%"
+				></div>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="text-sm text-[var(--color-text-secondary)]">
+					{current}/{total}
+				</span>
+				<ProgressRing
+					{percent}
+					size={28}
+					strokeWidth={3}
+					showLabel={false}
+					color="primary"
+				/>
+			</div>
+		</div>
+	</div>
+</header>

--- a/web/src/lib/components/memory/FilageSection.svelte
+++ b/web/src/lib/components/memory/FilageSection.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	/**
+	 * FilageSection Component
+	 * Grouped section with title, icon and count
+	 */
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		title: string;
+		icon: string;
+		count: number;
+		collapsed?: boolean;
+		children?: Snippet;
+	}
+
+	let { title, icon, count, collapsed = false, children }: Props = $props();
+
+	let isCollapsed = $state<boolean>(false);
+
+	// Initialize state from prop
+	$effect(() => {
+		isCollapsed = collapsed;
+	});
+
+	function toggleCollapse() {
+		isCollapsed = !isCollapsed;
+	}
+</script>
+
+<section class="mb-4">
+	<!-- Section header -->
+	<button
+		type="button"
+		onclick={toggleCollapse}
+		class="w-full flex items-center justify-between px-2 py-2 rounded-lg hover:bg-[var(--glass-subtle)] transition-colors"
+	>
+		<div class="flex items-center gap-2">
+			<span class="text-lg">{icon}</span>
+			<h2 class="text-sm font-semibold text-[var(--color-text-primary)]">
+				{title}
+			</h2>
+			<span class="text-xs px-1.5 py-0.5 rounded-full bg-[var(--glass-subtle)] text-[var(--color-text-secondary)]">
+				{count}
+			</span>
+		</div>
+		<span
+			class="text-[var(--color-text-tertiary)] transition-transform duration-200"
+			class:rotate-180={!isCollapsed}
+		>
+			▼
+		</span>
+	</button>
+
+	<!-- Section content -->
+	{#if !isCollapsed}
+		<div class="mt-2 space-y-2 animate-fade-in">
+			{#if children}{@render children()}{/if}
+		</div>
+	{/if}
+</section>
+
+<style>
+	@keyframes fade-in {
+		from {
+			opacity: 0;
+			transform: translateY(-4px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	.animate-fade-in {
+		animation: fade-in 0.2s ease-out;
+	}
+</style>

--- a/web/src/lib/components/memory/FilageWidget.svelte
+++ b/web/src/lib/components/memory/FilageWidget.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	/**
+	 * FilageWidget Component
+	 * Compact card for dashboard showing daily filage summary
+	 */
+	import { goto } from '$app/navigation';
+	import { Card } from '$lib/components/ui';
+	import ProgressRing from '$lib/components/ui/ProgressRing.svelte';
+
+	interface Props {
+		totalLectures: number;
+		completedToday: number;
+		questionsCount: number;
+		loading?: boolean;
+	}
+
+	let { totalLectures, completedToday, questionsCount, loading = false }: Props = $props();
+
+	const remaining = $derived(Math.max(0, totalLectures - completedToday));
+	const percent = $derived(totalLectures > 0 ? Math.round((completedToday / totalLectures) * 100) : 100);
+	const hasUrgent = $derived(questionsCount > 0);
+</script>
+
+<section class="mb-5" data-testid="filage-widget">
+	<h2 class="text-base font-semibold text-[var(--color-text-primary)] mb-2 flex items-center gap-2">
+		<span>📋</span> Filage du jour
+		{#if hasUrgent}
+			<span class="relative flex h-2 w-2">
+				<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
+				<span class="relative inline-flex rounded-full h-2 w-2 bg-red-500"></span>
+			</span>
+		{/if}
+	</h2>
+
+	<Card interactive onclick={() => goto('/memoires/filage')} class={hasUrgent ? 'ring-1 ring-[var(--color-warning)]/30' : ''}>
+		<div class="flex items-center justify-between p-3">
+			<div class="space-y-1">
+				<div class="flex items-baseline gap-2">
+					<span class="text-2xl font-bold text-[var(--color-text-primary)]">
+						{remaining}
+					</span>
+					<span class="text-sm text-[var(--color-text-tertiary)]">
+						{remaining === 1 ? 'note à revoir' : 'notes à revoir'}
+					</span>
+				</div>
+
+				{#if questionsCount > 0}
+					<p class="text-xs text-[var(--color-warning)] flex items-center gap-1">
+						<span>❓</span>
+						<span>{questionsCount} question{questionsCount > 1 ? 's' : ''} en attente</span>
+					</p>
+				{:else if completedToday > 0}
+					<p class="text-xs text-[var(--color-text-tertiary)]">
+						{completedToday} terminée{completedToday > 1 ? 's' : ''} aujourd'hui
+					</p>
+				{/if}
+			</div>
+
+			<div class="flex items-center gap-3">
+				{#if loading}
+					<div class="w-12 h-12 flex items-center justify-center">
+						<div class="w-6 h-6 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin"></div>
+					</div>
+				{:else}
+					<ProgressRing
+						{percent}
+						size={48}
+						color={percent === 100 ? 'success' : 'primary'}
+					/>
+				{/if}
+				<span class="text-[var(--color-text-tertiary)]">→</span>
+			</div>
+		</div>
+	</Card>
+</section>

--- a/web/src/lib/components/memory/LectureReviewCard.svelte
+++ b/web/src/lib/components/memory/LectureReviewCard.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	/**
+	 * LectureReviewCard Component
+	 * Enhanced review card for lecture sessions with quality score and questions
+	 */
+	import type { LectureSession } from '$lib/api/types/memory-cycles';
+	import { Card, Badge } from '$lib/components/ui';
+	import MarkdownPreview from '$lib/components/notes/MarkdownPreview.svelte';
+	import QualityScoreDisplay from './QualityScoreDisplay.svelte';
+	import QuestionsForm from './QuestionsForm.svelte';
+
+	interface Props {
+		session: LectureSession;
+		recentlyImproved?: boolean;
+		onViewNote?: () => void;
+		onAnswerQuestions?: (answers: Record<string, string>) => void;
+	}
+
+	let { session, recentlyImproved = false, onViewNote, onAnswerQuestions }: Props = $props();
+
+	// Note type icons
+	const typeIcons: Record<string, string> = {
+		personne: '👤',
+		organisation: '🏢',
+		projet: '📁',
+		concept: '💡',
+		lieu: '📍',
+		evenement: '📅',
+		produit: '📦',
+		default: '📝'
+	};
+
+	// Extract note type from title or use default
+	const noteType = $derived('default');
+	const icon = $derived(typeIcons[noteType] || typeIcons.default);
+</script>
+
+<div class="space-y-4">
+	<!-- Main card -->
+	<Card variant="glass">
+		<!-- Header -->
+		<div class="flex items-start justify-between mb-4">
+			<div class="flex items-center gap-3">
+				<div class="w-12 h-12 rounded-xl bg-[var(--glass-subtle)] flex items-center justify-center text-2xl">
+					{icon}
+				</div>
+				<div>
+					<h2 class="font-semibold text-[var(--color-text-primary)] text-lg">
+						{session.note_title}
+					</h2>
+					<div class="flex items-center gap-2 mt-1">
+						{#if recentlyImproved}
+							<Badge class="bg-purple-500/10 text-purple-500">
+								<span class="flex items-center gap-1">
+									<span>✨</span>
+									<span>Améliorée</span>
+								</span>
+							</Badge>
+						{/if}
+						{#if session.questions.length > 0}
+							<Badge class="bg-[var(--color-warning)]/10 text-[var(--color-warning)]">
+								<span class="flex items-center gap-1">
+									<span>❓</span>
+									<span>{session.questions.length} questions</span>
+								</span>
+							</Badge>
+						{/if}
+					</div>
+				</div>
+			</div>
+
+			<!-- Quality score -->
+			{#if session.quality_score !== null}
+				<QualityScoreDisplay score={session.quality_score} size={56} />
+			{/if}
+		</div>
+
+		<!-- Content preview -->
+		<div class="p-4 bg-[var(--glass-subtle)] rounded-xl max-h-[300px] overflow-y-auto">
+			<MarkdownPreview content={session.note_content} />
+		</div>
+
+		<!-- View full note button -->
+		{#if onViewNote}
+			<div class="mt-4 flex justify-end">
+				<button
+					type="button"
+					onclick={onViewNote}
+					class="text-sm text-[var(--color-accent)] hover:text-[var(--color-accent)]/80 transition-colors"
+				>
+					Voir la note complète →
+				</button>
+			</div>
+		{/if}
+	</Card>
+
+	<!-- Questions section -->
+	{#if session.questions.length > 0}
+		<QuestionsForm
+			questions={session.questions}
+			onAnswer={onAnswerQuestions}
+		/>
+	{/if}
+</div>

--- a/web/src/lib/components/memory/MemoryCyclesNotificationHandler.svelte
+++ b/web/src/lib/components/memory/MemoryCyclesNotificationHandler.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	/**
+	 * MemoryCyclesNotificationHandler Component
+	 * Handles WebSocket events for Memory Cycles and shows toast notifications
+	 */
+	import { onMount, onDestroy } from 'svelte';
+	import { browser } from '$app/environment';
+	import { toastStore } from '$lib/stores/toast.svelte';
+
+	// Memory Cycles event types
+	interface MemoryCyclesEvent {
+		event_type: 'retouche_done' | 'filage_ready' | 'questions_added' | 'lecture_completed';
+		note_id?: string;
+		note_title?: string;
+		count?: number;
+		quality_score?: number;
+		model_used?: string;
+		timestamp: string;
+	}
+
+	// Handle incoming events
+	function handleEvent(event: CustomEvent<MemoryCyclesEvent>) {
+		const data = event.detail;
+
+		switch (data.event_type) {
+			case 'retouche_done':
+				toastStore.success(
+					`✨ ${data.note_title || 'Note'} a été améliorée par ${data.model_used || 'Scapin'}`,
+					{ title: 'Note améliorée', duration: 5000 }
+				);
+				break;
+
+			case 'filage_ready':
+				toastStore.info(
+					`📋 Votre filage est prêt avec ${data.count || 0} note${(data.count || 0) > 1 ? 's' : ''} à revoir`,
+					{ title: 'Briefing prêt', duration: 5000 }
+				);
+				break;
+
+			case 'questions_added':
+				toastStore.warning(
+					`❓ ${data.count || 0} nouvelle${(data.count || 0) > 1 ? 's' : ''} question${(data.count || 0) > 1 ? 's' : ''} pour vous`,
+					{ title: 'Nouvelles questions', duration: 5000 }
+				);
+				break;
+
+			case 'lecture_completed':
+				if (data.quality_score !== undefined) {
+					toastStore.success(
+						`📚 ${data.note_title || 'Note'} - Score: ${data.quality_score}%`,
+						{ title: 'Lecture terminée', duration: 3000 }
+					);
+				}
+				break;
+		}
+	}
+
+	// Listen for Scapin events from WebSocket
+	function handleScapinEvent(event: CustomEvent) {
+		const data = event.detail;
+
+		// Check if it's a memory cycles event
+		if (
+			data.event_type === 'retouche_done' ||
+			data.event_type === 'filage_ready' ||
+			data.event_type === 'questions_added' ||
+			data.event_type === 'lecture_completed'
+		) {
+			handleEvent(new CustomEvent('memory-cycles', { detail: data }));
+		}
+	}
+
+	onMount(() => {
+		if (!browser) return;
+
+		// Listen for Scapin WebSocket events
+		window.addEventListener('scapin:event', handleScapinEvent as EventListener);
+	});
+
+	onDestroy(() => {
+		if (!browser) return;
+		window.removeEventListener('scapin:event', handleScapinEvent as EventListener);
+	});
+</script>
+
+<!-- This component doesn't render anything visible -->

--- a/web/src/lib/components/memory/QualityScoreDisplay.svelte
+++ b/web/src/lib/components/memory/QualityScoreDisplay.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	/**
+	 * QualityScoreDisplay Component
+	 * Displays quality score with ProgressRing and label
+	 */
+	import ProgressRing from '$lib/components/ui/ProgressRing.svelte';
+
+	interface Props {
+		score: number | null;
+		size?: number;
+		showLabel?: boolean;
+	}
+
+	let { score, size = 64, showLabel = true }: Props = $props();
+
+	// Determine color based on score
+	function getColor(s: number | null): 'success' | 'warning' | 'danger' | 'primary' {
+		if (s === null) return 'primary';
+		if (s >= 80) return 'success';
+		if (s >= 60) return 'warning';
+		return 'danger';
+	}
+
+	// Get label text
+	function getLabel(s: number | null): string {
+		if (s === null) return 'Non évaluée';
+		if (s >= 80) return 'Excellente';
+		if (s >= 60) return 'Bonne';
+		if (s >= 40) return 'Moyenne';
+		return 'À améliorer';
+	}
+
+	const color = $derived(getColor(score));
+	const label = $derived(getLabel(score));
+	const displayScore = $derived(score ?? 0);
+</script>
+
+<div class="flex flex-col items-center gap-2">
+	<ProgressRing
+		percent={displayScore}
+		{size}
+		strokeWidth={size > 48 ? 6 : 4}
+		{color}
+	/>
+	{#if showLabel}
+		<div class="text-center">
+			<p class="text-xs font-medium text-[var(--color-text-secondary)]">
+				{label}
+			</p>
+			{#if score !== null}
+				<p class="text-[10px] text-[var(--color-text-tertiary)]">
+					Score de qualité
+				</p>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/web/src/lib/components/memory/QuestionCard.svelte
+++ b/web/src/lib/components/memory/QuestionCard.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+	/**
+	 * QuestionCard Component
+	 * Card for displaying and answering a single pending question
+	 */
+	import type { PendingQuestion } from '$lib/api/types/memory-cycles';
+	import { Card, Badge } from '$lib/components/ui';
+
+	interface Props {
+		question: PendingQuestion;
+		onAnswer?: (answer: string) => void;
+		onSkip?: () => void;
+		disabled?: boolean;
+	}
+
+	let { question, onAnswer, onSkip, disabled = false }: Props = $props();
+
+	let answer = $state('');
+	let isSubmitting = $state(false);
+
+	async function handleSubmit() {
+		if (!answer.trim() || !onAnswer) return;
+
+		isSubmitting = true;
+		try {
+			await onAnswer(answer.trim());
+			answer = '';
+		} finally {
+			isSubmitting = false;
+		}
+	}
+
+	// Format relative time
+	function formatRelativeTime(dateStr: string): string {
+		const date = new Date(dateStr);
+		const now = new Date();
+		const diffMs = now.getTime() - date.getTime();
+		const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+		const diffDays = Math.floor(diffHours / 24);
+
+		if (diffDays > 0) {
+			return `il y a ${diffDays}j`;
+		} else if (diffHours > 0) {
+			return `il y a ${diffHours}h`;
+		} else {
+			return 'récemment';
+		}
+	}
+</script>
+
+<Card variant="glass" class="border-[var(--color-warning)]/20">
+	<div class="space-y-3">
+		<!-- Header -->
+		<div class="flex items-start justify-between gap-2">
+			<div class="flex-1 min-w-0">
+				<p class="text-sm font-medium text-[var(--color-text-primary)]">
+					{question.question_text}
+				</p>
+				<div class="flex items-center gap-2 mt-1">
+					<Badge class="bg-[var(--glass-subtle)] text-[var(--color-text-tertiary)]">
+						{question.note_title}
+					</Badge>
+					<span class="text-xs text-[var(--color-text-tertiary)]">
+						{formatRelativeTime(question.created_at)}
+					</span>
+				</div>
+			</div>
+			<span class="text-lg flex-shrink-0">❓</span>
+		</div>
+
+		<!-- Answer input -->
+		{#if !question.answered}
+			<div class="space-y-2">
+				<textarea
+					class="w-full px-3 py-2 text-sm bg-[var(--glass-subtle)] border border-[var(--glass-border-subtle)] rounded-xl
+						text-[var(--color-text-primary)] placeholder-[var(--color-text-tertiary)]
+						focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/50 focus:border-transparent
+						resize-none transition-all"
+					rows="2"
+					placeholder="Ta réponse..."
+					disabled={disabled || isSubmitting}
+					bind:value={answer}
+				></textarea>
+
+				<div class="flex items-center justify-end gap-2">
+					{#if onSkip}
+						<button
+							type="button"
+							onclick={onSkip}
+							disabled={disabled || isSubmitting}
+							class="px-3 py-1.5 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors disabled:opacity-50"
+						>
+							Passer
+						</button>
+					{/if}
+					<button
+						type="button"
+						onclick={handleSubmit}
+						disabled={disabled || isSubmitting || !answer.trim()}
+						class="px-4 py-1.5 text-sm bg-[var(--color-accent)] text-white rounded-xl
+							hover:bg-[var(--color-accent)]/90 transition-colors disabled:opacity-50
+							liquid-press"
+					>
+						{#if isSubmitting}
+							<span class="inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
+						{:else}
+							Répondre
+						{/if}
+					</button>
+				</div>
+			</div>
+		{:else}
+			<!-- Answered state -->
+			<div class="p-3 bg-green-500/10 rounded-xl border border-green-500/20">
+				<p class="text-sm text-green-600 dark:text-green-400">
+					{question.answer}
+				</p>
+			</div>
+		{/if}
+	</div>
+</Card>

--- a/web/src/lib/components/memory/QuestionsForm.svelte
+++ b/web/src/lib/components/memory/QuestionsForm.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	/**
+	 * QuestionsForm Component
+	 * Form for answering questions during lecture review
+	 */
+	import { Card, Button } from '$lib/components/ui';
+
+	interface Props {
+		questions: string[];
+		onAnswer?: (answers: Record<string, string>) => void;
+		disabled?: boolean;
+	}
+
+	let { questions, onAnswer, disabled = false }: Props = $props();
+
+	// Track answers for each question
+	let answers = $state<Record<string, string>>({});
+
+	function handleSubmit() {
+		if (onAnswer) {
+			onAnswer(answers);
+		}
+	}
+
+	function updateAnswer(index: number, value: string) {
+		answers = { ...answers, [String(index)]: value };
+	}
+
+	const hasAnyAnswer = $derived(
+		Object.values(answers).some((a) => a.trim().length > 0)
+	);
+</script>
+
+{#if questions.length > 0}
+	<Card variant="glass" class="border-[var(--color-warning)]/30">
+		<div class="space-y-4">
+			<div class="flex items-center gap-2">
+				<span class="text-lg">❓</span>
+				<h3 class="font-medium text-[var(--color-text-primary)]">
+					Questions pour toi
+				</h3>
+				<span class="text-xs px-1.5 py-0.5 rounded-full bg-[var(--color-warning)]/10 text-[var(--color-warning)]">
+					{questions.length}
+				</span>
+			</div>
+
+			<div class="space-y-3">
+				{#each questions as question, i}
+					<div class="space-y-1.5">
+						<label
+							for="question-{i}"
+							class="block text-sm text-[var(--color-text-secondary)]"
+						>
+							{question}
+						</label>
+						<textarea
+							id="question-{i}"
+							class="w-full px-3 py-2 text-sm bg-[var(--glass-subtle)] border border-[var(--glass-border-subtle)] rounded-xl
+								text-[var(--color-text-primary)] placeholder-[var(--color-text-tertiary)]
+								focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/50 focus:border-transparent
+								resize-none transition-all"
+							rows="2"
+							placeholder="Ta réponse..."
+							{disabled}
+							value={answers[String(i)] || ''}
+							oninput={(e) => updateAnswer(i, e.currentTarget.value)}
+						></textarea>
+					</div>
+				{/each}
+			</div>
+
+			{#if hasAnyAnswer}
+				<div class="flex justify-end">
+					<button
+						type="button"
+						onclick={handleSubmit}
+						{disabled}
+						class="px-4 py-2 text-sm bg-[var(--color-accent)] text-white rounded-xl
+							hover:bg-[var(--color-accent)]/90 transition-colors disabled:opacity-50
+							liquid-press"
+					>
+						Enregistrer les réponses
+					</button>
+				</div>
+			{/if}
+
+			<p class="text-xs text-[var(--color-text-tertiary)]">
+				Ces questions ont été générées par Scapin pour enrichir cette note.
+				Tes réponses seront intégrées automatiquement.
+			</p>
+		</div>
+	</Card>
+{/if}

--- a/web/src/lib/components/memory/QuestionsGroupedList.svelte
+++ b/web/src/lib/components/memory/QuestionsGroupedList.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	/**
+	 * QuestionsGroupedList Component
+	 * List of questions grouped by note
+	 */
+	import type { PendingQuestion } from '$lib/api/types/memory-cycles';
+	import QuestionCard from './QuestionCard.svelte';
+	import { Card } from '$lib/components/ui';
+
+	interface Props {
+		questions: PendingQuestion[];
+		onAnswer?: (questionId: string, answer: string) => void;
+		onSkip?: (questionId: string) => void;
+		groupByNote?: boolean;
+		disabled?: boolean;
+	}
+
+	let { questions, onAnswer, onSkip, groupByNote = true, disabled = false }: Props = $props();
+
+	// Group questions by note
+	const groupedQuestions = $derived.by(() => {
+		if (!groupByNote) return { '': questions };
+
+		const groups: Record<string, PendingQuestion[]> = {};
+		for (const q of questions) {
+			const key = q.note_title;
+			if (!groups[key]) {
+				groups[key] = [];
+			}
+			groups[key].push(q);
+		}
+		return groups;
+	});
+
+	const groupKeys = $derived(Object.keys(groupedQuestions).sort());
+
+	function handleAnswer(questionId: string) {
+		return (answer: string) => {
+			if (onAnswer) {
+				onAnswer(questionId, answer);
+			}
+		};
+	}
+
+	function handleSkip(questionId: string) {
+		return () => {
+			if (onSkip) {
+				onSkip(questionId);
+			}
+		};
+	}
+</script>
+
+{#if questions.length === 0}
+	<div class="flex flex-col items-center justify-center py-12 text-center">
+		<span class="text-4xl mb-3">🎉</span>
+		<h3 class="text-lg font-medium text-[var(--color-text-primary)] mb-1">
+			Aucune question en attente
+		</h3>
+		<p class="text-sm text-[var(--color-text-secondary)]">
+			Toutes les questions ont été répondues
+		</p>
+	</div>
+{:else if groupByNote}
+	<div class="space-y-6">
+		{#each groupKeys as noteTitle}
+			{@const noteQuestions = groupedQuestions[noteTitle]}
+			<section>
+				<!-- Note group header -->
+				<div class="flex items-center gap-2 mb-3">
+					<span class="text-lg">📝</span>
+					<h3 class="font-medium text-[var(--color-text-primary)]">
+						{noteTitle}
+					</h3>
+					<span class="text-xs px-1.5 py-0.5 rounded-full bg-[var(--color-warning)]/10 text-[var(--color-warning)]">
+						{noteQuestions.length}
+					</span>
+				</div>
+
+				<!-- Questions list -->
+				<div class="space-y-3">
+					{#each noteQuestions as question (question.question_id)}
+						<QuestionCard
+							{question}
+							onAnswer={handleAnswer(question.question_id)}
+							onSkip={handleSkip(question.question_id)}
+							{disabled}
+						/>
+					{/each}
+				</div>
+			</section>
+		{/each}
+	</div>
+{:else}
+	<div class="space-y-3">
+		{#each questions as question (question.question_id)}
+			<QuestionCard
+				{question}
+				onAnswer={handleAnswer(question.question_id)}
+				onSkip={handleSkip(question.question_id)}
+				{disabled}
+			/>
+		{/each}
+	</div>
+{/if}

--- a/web/src/lib/components/memory/RetoucheTimeline.svelte
+++ b/web/src/lib/components/memory/RetoucheTimeline.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	/**
+	 * RetoucheTimeline Component
+	 * Timeline showing AI improvement history for a note
+	 */
+	import type { RetoucheEntry } from '$lib/api/types/memory-cycles';
+	import { Card, Badge } from '$lib/components/ui';
+	
+	interface Props {
+		retouches: RetoucheEntry[];
+		showChart?: boolean;
+	}
+
+	let { retouches, showChart = true }: Props = $props();
+
+	// Model colors
+	const modelColors: Record<string, string> = {
+		haiku: 'bg-emerald-500',
+		sonnet: 'bg-blue-500',
+		opus: 'bg-purple-500'
+	};
+
+	const modelLabels: Record<string, string> = {
+		haiku: 'Haiku',
+		sonnet: 'Sonnet',
+		opus: 'Opus'
+	};
+
+	// Format date
+	function formatDate(dateStr: string): string {
+		const date = new Date(dateStr);
+		return date.toLocaleDateString('fr-FR', {
+			day: 'numeric',
+			month: 'short',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	// Quality delta display
+	function formatDelta(before: number | null, after: number | null): string {
+		if (before === null || after === null) return '';
+		const delta = after - before;
+		if (delta > 0) return `+${delta}`;
+		if (delta < 0) return `${delta}`;
+		return '=';
+	}
+
+	function getDeltaColor(before: number | null, after: number | null): string {
+		if (before === null || after === null) return 'text-[var(--color-text-tertiary)]';
+		const delta = after - before;
+		if (delta > 0) return 'text-green-500';
+		if (delta < 0) return 'text-red-500';
+		return 'text-[var(--color-text-tertiary)]';
+	}
+
+	// Chart data
+	const chartData = $derived(
+		retouches
+			.filter((r) => r.quality_after !== null)
+			.map((r) => r.quality_after!)
+	);
+</script>
+
+{#if retouches.length === 0}
+	<Card variant="glass-subtle" padding="sm">
+		<div class="text-center py-4">
+			<span class="text-2xl mb-2 block">✨</span>
+			<p class="text-sm text-[var(--color-text-secondary)]">
+				Aucune amélioration IA pour cette note
+			</p>
+		</div>
+	</Card>
+{:else}
+	<div class="space-y-4">
+		<!-- Quality trend mini chart -->
+		{#if showChart && chartData.length > 1}
+			<Card variant="glass-subtle" padding="sm">
+				<h4 class="text-xs font-medium text-[var(--color-text-tertiary)] mb-2">
+					Évolution de la qualité
+				</h4>
+				<div class="flex items-end gap-1 h-12">
+					{#each chartData as score, i}
+						{@const height = Math.max(4, (score / 100) * 48)}
+						{@const isLast = i === chartData.length - 1}
+						<div
+							class="flex-1 rounded-t transition-all {isLast ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-accent)]/40'}"
+							style="height: {height}px"
+							title="{score}%"
+						></div>
+					{/each}
+				</div>
+				<div class="flex justify-between mt-1 text-[10px] text-[var(--color-text-tertiary)]">
+					<span>Premier</span>
+					<span>Dernier: {chartData[chartData.length - 1]}%</span>
+				</div>
+			</Card>
+		{/if}
+
+		<!-- Timeline -->
+		<div class="relative">
+			<!-- Vertical line -->
+			<div class="absolute left-4 top-0 bottom-0 w-0.5 bg-[var(--glass-border-subtle)]"></div>
+
+			<!-- Timeline entries -->
+			<div class="space-y-4">
+				{#each retouches as retouche, i (retouche.retouche_id)}
+					<div class="relative flex gap-4">
+						<!-- Dot -->
+						<div class="relative z-10 flex-shrink-0">
+							<div class="w-8 h-8 rounded-full {modelColors[retouche.model_used]} flex items-center justify-center">
+								<span class="text-xs text-white font-medium">
+									{retouche.model_used.charAt(0).toUpperCase()}
+								</span>
+							</div>
+						</div>
+
+						<!-- Content -->
+						<Card variant="glass-subtle" class="flex-1" padding="sm">
+							<div class="flex items-start justify-between gap-2 mb-2">
+								<div>
+									<Badge class="bg-[var(--glass-subtle)] text-[var(--color-text-secondary)]">
+										{modelLabels[retouche.model_used]}
+									</Badge>
+									<span class="text-xs text-[var(--color-text-tertiary)] ml-2">
+										{formatDate(retouche.timestamp)}
+									</span>
+								</div>
+								{#if retouche.quality_before !== null || retouche.quality_after !== null}
+									<span class="text-sm font-medium {getDeltaColor(retouche.quality_before, retouche.quality_after)}">
+										{formatDelta(retouche.quality_before, retouche.quality_after)}
+									</span>
+								{/if}
+							</div>
+
+							<p class="text-sm text-[var(--color-text-secondary)]">
+								{retouche.changes_summary}
+							</p>
+
+							<!-- Quality scores -->
+							{#if retouche.quality_before !== null || retouche.quality_after !== null}
+								<div class="flex items-center gap-3 mt-2 text-xs">
+									{#if retouche.quality_before !== null}
+										<span class="text-[var(--color-text-tertiary)]">
+											Avant: {retouche.quality_before}%
+										</span>
+									{/if}
+									{#if retouche.quality_after !== null}
+										<span class="text-[var(--color-text-primary)] font-medium">
+											Après: {retouche.quality_after}%
+										</span>
+									{/if}
+									<span class="text-[var(--color-text-tertiary)]">
+										Conf: {Math.round(retouche.confidence * 100)}%
+									</span>
+								</div>
+							{/if}
+						</Card>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/web/src/lib/components/memory/StreakDisplay.svelte
+++ b/web/src/lib/components/memory/StreakDisplay.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	/**
+	 * StreakDisplay Component
+	 * Shows review streak with flame animation and encouragement
+	 */
+	import type { StreakInfo } from '$lib/api/types/memory-cycles';
+
+	interface Props {
+		streak: StreakInfo;
+		compact?: boolean;
+	}
+
+	let { streak, compact = false }: Props = $props();
+
+	// Get encouragement message based on streak
+	function getEncouragement(days: number): string {
+		if (days === 0) return 'Commencez une nouvelle série !';
+		if (days === 1) return 'Premier jour, continuez !';
+		if (days < 3) return 'Beau départ !';
+		if (days < 7) return 'Excellente progression !';
+		if (days < 14) return 'Une semaine complète !';
+		if (days < 30) return 'Impressionnant !';
+		if (days < 100) return 'Incroyable discipline !';
+		return 'Légendaire !';
+	}
+
+	// Generate heatmap for last 7 days
+	function generateHeatmap(): { day: string; active: boolean }[] {
+		const days: { day: string; active: boolean }[] = [];
+		const today = new Date();
+		const lastReview = streak.last_review_date ? new Date(streak.last_review_date) : null;
+
+		for (let i = 6; i >= 0; i--) {
+			const date = new Date(today);
+			date.setDate(date.getDate() - i);
+			const dayName = date.toLocaleDateString('fr-FR', { weekday: 'narrow' });
+
+			// Simple heuristic: if within streak range, mark as active
+			let active = false;
+			if (lastReview && streak.current_streak > 0) {
+				const diffDays = Math.floor((today.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+				active = diffDays < streak.current_streak;
+			}
+
+			days.push({ day: dayName, active });
+		}
+
+		return days;
+	}
+
+	const heatmap = $derived(generateHeatmap());
+	const encouragement = $derived(getEncouragement(streak.current_streak));
+	const isOnFire = $derived(streak.current_streak >= 3);
+</script>
+
+{#if compact}
+	<!-- Compact display for widgets -->
+	<div class="flex items-center gap-2">
+		<span class="text-lg {isOnFire ? 'animate-pulse' : ''}">
+			{isOnFire ? '🔥' : '✨'}
+		</span>
+		<span class="font-bold text-[var(--color-text-primary)]">
+			{streak.current_streak}
+		</span>
+		<span class="text-xs text-[var(--color-text-tertiary)]">
+			jour{streak.current_streak > 1 ? 's' : ''}
+		</span>
+	</div>
+{:else}
+	<!-- Full display -->
+	<div class="space-y-3">
+		<!-- Main streak display -->
+		<div class="flex items-center gap-3">
+			<div class="relative">
+				<span class="text-4xl {isOnFire ? 'animate-bounce' : ''}">
+					{isOnFire ? '🔥' : '✨'}
+				</span>
+				{#if isOnFire}
+					<span class="absolute -top-1 -right-1 text-sm animate-ping">🔥</span>
+				{/if}
+			</div>
+			<div>
+				<p class="text-3xl font-bold text-[var(--color-text-primary)]">
+					{streak.current_streak}
+					<span class="text-base font-normal text-[var(--color-text-secondary)]">
+						jour{streak.current_streak > 1 ? 's' : ''}
+					</span>
+				</p>
+				<p class="text-sm text-[var(--color-accent)]">
+					{encouragement}
+				</p>
+			</div>
+		</div>
+
+		<!-- Heatmap -->
+		<div class="flex items-center gap-1">
+			{#each heatmap as { day, active }}
+				<div class="flex flex-col items-center gap-1">
+					<div
+						class="w-6 h-6 rounded-lg transition-colors
+							{active
+								? 'bg-[var(--color-accent)]'
+								: 'bg-[var(--glass-subtle)]'}"
+					></div>
+					<span class="text-[10px] text-[var(--color-text-tertiary)]">
+						{day}
+					</span>
+				</div>
+			{/each}
+		</div>
+
+		<!-- Stats -->
+		<div class="flex items-center gap-4 text-xs text-[var(--color-text-tertiary)]">
+			<span>Record: {streak.longest_streak}j</span>
+			{#if streak.last_review_date}
+				<span>
+					Dernière: {new Date(streak.last_review_date).toLocaleDateString('fr-FR')}
+				</span>
+			{/if}
+		</div>
+
+		<!-- Warning if streak at risk -->
+		{#if !streak.streak_maintained}
+			<div class="p-2 bg-[var(--color-warning)]/10 rounded-xl border border-[var(--color-warning)]/30">
+				<p class="text-xs text-[var(--color-warning)]">
+					⚠️ Révisez aujourd'hui pour maintenir votre série !
+				</p>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	@keyframes bounce {
+		0%, 100% { transform: translateY(0); }
+		50% { transform: translateY(-5px); }
+	}
+
+	.animate-bounce {
+		animation: bounce 0.5s ease-in-out infinite;
+	}
+</style>

--- a/web/src/lib/components/memory/index.ts
+++ b/web/src/lib/components/memory/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Memory Cycles Components
+ * Components for Filage, Lecture, and Memory management
+ */
+
+export { default as FilageLectureCard } from './FilageLectureCard.svelte';
+export { default as FilageProgressHeader } from './FilageProgressHeader.svelte';
+export { default as FilageSection } from './FilageSection.svelte';
+export { default as FilageWidget } from './FilageWidget.svelte';
+export { default as QualityScoreDisplay } from './QualityScoreDisplay.svelte';
+export { default as QuestionsForm } from './QuestionsForm.svelte';
+export { default as LectureReviewCard } from './LectureReviewCard.svelte';
+export { default as QuestionCard } from './QuestionCard.svelte';
+export { default as QuestionsGroupedList } from './QuestionsGroupedList.svelte';
+export { default as RetoucheTimeline } from './RetoucheTimeline.svelte';
+export { default as StreakDisplay } from './StreakDisplay.svelte';
+export { default as MemoryCyclesNotificationHandler } from './MemoryCyclesNotificationHandler.svelte';

--- a/web/src/lib/stores/gamification.svelte.ts
+++ b/web/src/lib/stores/gamification.svelte.ts
@@ -1,0 +1,371 @@
+/**
+ * Gamification Store
+ * Tracks streaks, badges, and XP for memory review engagement
+ */
+import type { StreakInfo, GamificationStats, ReviewBadge } from '$lib/api/types/memory-cycles';
+
+// ============================================================================
+// LOCAL STORAGE KEYS
+// ============================================================================
+
+const STORAGE_KEY = 'scapin_gamification';
+
+// ============================================================================
+// DEFAULT VALUES
+// ============================================================================
+
+const DEFAULT_STREAK: StreakInfo = {
+	current_streak: 0,
+	longest_streak: 0,
+	last_review_date: null,
+	streak_maintained: false
+};
+
+const DEFAULT_BADGES: ReviewBadge[] = [
+	{
+		badge_id: 'first_review',
+		name: 'Premier pas',
+		description: 'Complétez votre première révision',
+		icon: '🌱',
+		earned_at: null,
+		progress: 0
+	},
+	{
+		badge_id: 'week_streak',
+		name: 'Semaine parfaite',
+		description: 'Maintenez une série de 7 jours',
+		icon: '🔥',
+		earned_at: null,
+		progress: 0
+	},
+	{
+		badge_id: 'hundred_reviews',
+		name: 'Centurion',
+		description: 'Complétez 100 révisions',
+		icon: '💯',
+		earned_at: null,
+		progress: 0
+	},
+	{
+		badge_id: 'month_streak',
+		name: 'Mois entier',
+		description: 'Maintenez une série de 30 jours',
+		icon: '🏆',
+		earned_at: null,
+		progress: 0
+	},
+	{
+		badge_id: 'early_bird',
+		name: 'Lève-tôt',
+		description: 'Révisez avant 8h du matin',
+		icon: '🌅',
+		earned_at: null,
+		progress: 0
+	},
+	{
+		badge_id: 'perfect_score',
+		name: 'Excellence',
+		description: 'Obtenez un score de 5 sur 10 notes consécutives',
+		icon: '⭐',
+		earned_at: null,
+		progress: 0
+	}
+];
+
+const DEFAULT_STATS: GamificationStats = {
+	streak: DEFAULT_STREAK,
+	badges: DEFAULT_BADGES,
+	total_reviews: 0,
+	reviews_this_week: 0,
+	xp_total: 0,
+	level: 1
+};
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+interface GamificationState {
+	stats: GamificationStats;
+	loading: boolean;
+	lastUpdated: Date | null;
+}
+
+let state = $state<GamificationState>({
+	stats: DEFAULT_STATS,
+	loading: false,
+	lastUpdated: null
+});
+
+// ============================================================================
+// PERSISTENCE
+// ============================================================================
+
+function loadFromStorage(): GamificationStats | null {
+	if (typeof localStorage === 'undefined') return null;
+
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored) {
+			return JSON.parse(stored);
+		}
+	} catch (err) {
+		console.error('Failed to load gamification data:', err);
+	}
+	return null;
+}
+
+function saveToStorage(stats: GamificationStats): void {
+	if (typeof localStorage === 'undefined') return;
+
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(stats));
+	} catch (err) {
+		console.error('Failed to save gamification data:', err);
+	}
+}
+
+// ============================================================================
+// COMPUTED VALUES
+// ============================================================================
+
+const level = $derived(Math.floor(state.stats.xp_total / 100) + 1);
+const xpForNextLevel = $derived((level) * 100);
+const xpProgress = $derived(state.stats.xp_total % 100);
+const earnedBadges = $derived(state.stats.badges.filter((b) => b.earned_at !== null));
+const pendingBadges = $derived(state.stats.badges.filter((b) => b.earned_at === null));
+
+// ============================================================================
+// ACTIONS
+// ============================================================================
+
+function initialize(): void {
+	const stored = loadFromStorage();
+	if (stored) {
+		state.stats = stored;
+		state.lastUpdated = new Date();
+	}
+
+	// Check if streak needs to be reset
+	checkStreakStatus();
+}
+
+function checkStreakStatus(): void {
+	const { streak } = state.stats;
+	if (!streak.last_review_date) return;
+
+	const lastReview = new Date(streak.last_review_date);
+	const today = new Date();
+	today.setHours(0, 0, 0, 0);
+	lastReview.setHours(0, 0, 0, 0);
+
+	const diffDays = Math.floor((today.getTime() - lastReview.getTime()) / (1000 * 60 * 60 * 24));
+
+	// If more than 1 day since last review, streak is broken
+	if (diffDays > 1) {
+		state.stats = {
+			...state.stats,
+			streak: {
+				...streak,
+				current_streak: 0,
+				streak_maintained: false
+			}
+		};
+		saveToStorage(state.stats);
+	} else if (diffDays === 1) {
+		// Streak is at risk - need to review today
+		state.stats = {
+			...state.stats,
+			streak: {
+				...streak,
+				streak_maintained: false
+			}
+		};
+	}
+}
+
+function recordReview(quality: number): void {
+	const today = new Date();
+	const todayStr = today.toISOString().split('T')[0];
+	const { streak } = state.stats;
+
+	// Check if this is first review today
+	let newStreak = streak.current_streak;
+	let lastReviewDate = streak.last_review_date;
+
+	if (lastReviewDate) {
+		const lastDate = lastReviewDate.split('T')[0];
+		if (lastDate !== todayStr) {
+			// New day, increment streak
+			newStreak++;
+		}
+	} else {
+		// First ever review
+		newStreak = 1;
+	}
+
+	// Update longest streak
+	const newLongest = Math.max(streak.longest_streak, newStreak);
+
+	// Calculate XP (base 10, bonus for quality)
+	const baseXP = 10;
+	const qualityBonus = quality >= 4 ? 5 : quality >= 3 ? 2 : 0;
+	const streakBonus = Math.min(newStreak, 10); // Max 10 bonus for streak
+	const totalXP = baseXP + qualityBonus + streakBonus;
+
+	// Update stats
+	state.stats = {
+		...state.stats,
+		streak: {
+			current_streak: newStreak,
+			longest_streak: newLongest,
+			last_review_date: today.toISOString(),
+			streak_maintained: true
+		},
+		total_reviews: state.stats.total_reviews + 1,
+		reviews_this_week: state.stats.reviews_this_week + 1,
+		xp_total: state.stats.xp_total + totalXP,
+		level: Math.floor((state.stats.xp_total + totalXP) / 100) + 1
+	};
+
+	// Check for badge unlocks
+	checkBadgeUnlocks(quality);
+
+	// Save
+	saveToStorage(state.stats);
+	state.lastUpdated = new Date();
+}
+
+function checkBadgeUnlocks(quality: number): void {
+	const now = new Date().toISOString();
+	const badges = [...state.stats.badges];
+	let updated = false;
+
+	// First review badge
+	const firstReview = badges.find((b) => b.badge_id === 'first_review');
+	if (firstReview && !firstReview.earned_at && state.stats.total_reviews >= 1) {
+		firstReview.earned_at = now;
+		firstReview.progress = 100;
+		updated = true;
+	}
+
+	// Week streak badge
+	const weekStreak = badges.find((b) => b.badge_id === 'week_streak');
+	if (weekStreak && !weekStreak.earned_at) {
+		weekStreak.progress = Math.min(100, (state.stats.streak.current_streak / 7) * 100);
+		if (state.stats.streak.current_streak >= 7) {
+			weekStreak.earned_at = now;
+			updated = true;
+		}
+	}
+
+	// Hundred reviews badge
+	const hundredReviews = badges.find((b) => b.badge_id === 'hundred_reviews');
+	if (hundredReviews && !hundredReviews.earned_at) {
+		hundredReviews.progress = Math.min(100, (state.stats.total_reviews / 100) * 100);
+		if (state.stats.total_reviews >= 100) {
+			hundredReviews.earned_at = now;
+			updated = true;
+		}
+	}
+
+	// Month streak badge
+	const monthStreak = badges.find((b) => b.badge_id === 'month_streak');
+	if (monthStreak && !monthStreak.earned_at) {
+		monthStreak.progress = Math.min(100, (state.stats.streak.current_streak / 30) * 100);
+		if (state.stats.streak.current_streak >= 30) {
+			monthStreak.earned_at = now;
+			updated = true;
+		}
+	}
+
+	// Early bird badge
+	const earlyBird = badges.find((b) => b.badge_id === 'early_bird');
+	if (earlyBird && !earlyBird.earned_at) {
+		const hour = new Date().getHours();
+		if (hour < 8) {
+			earlyBird.earned_at = now;
+			earlyBird.progress = 100;
+			updated = true;
+		}
+	}
+
+	if (updated) {
+		state.stats = { ...state.stats, badges };
+	}
+}
+
+function resetStats(): void {
+	state.stats = DEFAULT_STATS;
+	saveToStorage(state.stats);
+	state.lastUpdated = new Date();
+}
+
+// ============================================================================
+// EXPORT STORE
+// ============================================================================
+
+export const gamificationStore = {
+	// State getters
+	get stats() {
+		return state.stats;
+	},
+	get loading() {
+		return state.loading;
+	},
+	get lastUpdated() {
+		return state.lastUpdated;
+	},
+
+	// Streak getters
+	get streak() {
+		return state.stats.streak;
+	},
+	get currentStreak() {
+		return state.stats.streak.current_streak;
+	},
+	get longestStreak() {
+		return state.stats.streak.longest_streak;
+	},
+
+	// XP/Level getters
+	get level() {
+		return level;
+	},
+	get xpTotal() {
+		return state.stats.xp_total;
+	},
+	get xpProgress() {
+		return xpProgress;
+	},
+	get xpForNextLevel() {
+		return xpForNextLevel;
+	},
+
+	// Badge getters
+	get badges() {
+		return state.stats.badges;
+	},
+	get earnedBadges() {
+		return earnedBadges;
+	},
+	get pendingBadges() {
+		return pendingBadges;
+	},
+
+	// Stats getters
+	get totalReviews() {
+		return state.stats.total_reviews;
+	},
+	get reviewsThisWeek() {
+		return state.stats.reviews_this_week;
+	},
+
+	// Actions
+	initialize,
+	recordReview,
+	checkStreakStatus,
+	resetStats
+};
+
+export type { StreakInfo, GamificationStats, ReviewBadge };

--- a/web/src/lib/stores/memory-cycles.svelte.ts
+++ b/web/src/lib/stores/memory-cycles.svelte.ts
@@ -1,0 +1,427 @@
+/**
+ * Memory Cycles Store
+ * Manages Filage (daily briefing) and Lecture (review sessions) state
+ */
+import { ApiError } from '$lib/api';
+import type {
+	Filage,
+	FilageLecture,
+	LectureSession,
+	LectureResult,
+	PendingQuestion,
+	QuestionsListResponse
+} from '$lib/api/types/memory-cycles';
+
+// ============================================================================
+// API FUNCTIONS (will be imported from client.ts once added)
+// ============================================================================
+
+const API_BASE = '/api';
+
+async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> {
+	const url = `${API_BASE}${endpoint}`;
+	const headers: HeadersInit = {
+		'Content-Type': 'application/json',
+		...options?.headers
+	};
+
+	// Get auth token from localStorage
+	const token = typeof localStorage !== 'undefined' ? localStorage.getItem('scapin_token') : null;
+	if (token) {
+		(headers as Record<string, string>)['Authorization'] = `Bearer ${token}`;
+	}
+
+	const response = await fetch(url, { ...options, headers });
+
+	if (!response.ok) {
+		const errorData = await response.json().catch(() => ({}));
+		throw new ApiError(response.status, errorData.detail || `HTTP ${response.status}`);
+	}
+
+	const data = await response.json();
+	if (!data.success) {
+		throw new ApiError(500, data.error || 'Unknown error');
+	}
+
+	return data.data as T;
+}
+
+// API functions for Memory Cycles
+async function apiGetFilage(maxLectures = 20): Promise<Filage> {
+	return fetchApi<Filage>(`/briefing/filage?max_lectures=${maxLectures}`);
+}
+
+async function apiStartLecture(noteId: string): Promise<LectureSession> {
+	return fetchApi<LectureSession>(`/briefing/lecture/${encodeURIComponent(noteId)}/start`, {
+		method: 'POST'
+	});
+}
+
+async function apiCompleteLecture(
+	noteId: string,
+	quality: number,
+	answers?: Record<string, string>
+): Promise<LectureResult> {
+	return fetchApi<LectureResult>(`/briefing/lecture/${encodeURIComponent(noteId)}/complete`, {
+		method: 'POST',
+		body: JSON.stringify({ quality, answers })
+	});
+}
+
+async function apiGetPendingQuestions(limit = 50): Promise<QuestionsListResponse> {
+	return fetchApi<QuestionsListResponse>(`/notes/questions/pending?limit=${limit}`);
+}
+
+async function apiAnswerQuestion(
+	questionId: string,
+	answer: string
+): Promise<{ success: boolean }> {
+	return fetchApi<{ success: boolean }>(`/notes/questions/${encodeURIComponent(questionId)}/answer`, {
+		method: 'POST',
+		body: JSON.stringify({ answer })
+	});
+}
+
+// ============================================================================
+// STORE STATE
+// ============================================================================
+
+interface MemoryCyclesState {
+	filage: Filage | null;
+	currentSession: LectureSession | null;
+	currentIndex: number;
+	completedToday: number;
+	loading: boolean;
+	error: string | null;
+	lastFetch: Date | null;
+	// Questions state
+	pendingQuestions: PendingQuestion[];
+	questionsLoading: boolean;
+}
+
+// Create reactive state
+let state = $state<MemoryCyclesState>({
+	filage: null,
+	currentSession: null,
+	currentIndex: 0,
+	completedToday: 0,
+	loading: false,
+	error: null,
+	lastFetch: null,
+	pendingQuestions: [],
+	questionsLoading: false
+});
+
+// ============================================================================
+// DERIVED VALUES
+// ============================================================================
+
+const currentLecture = $derived(
+	state.filage?.lectures[state.currentIndex] ?? null
+);
+
+const hasNext = $derived(
+	state.filage !== null && state.currentIndex < state.filage.lectures.length - 1
+);
+
+const hasPrevious = $derived(state.currentIndex > 0);
+
+const totalLectures = $derived(state.filage?.total_lectures ?? 0);
+
+const progress = $derived({
+	current: state.currentIndex + 1,
+	total: state.filage?.lectures.length ?? 0,
+	percent: state.filage?.lectures.length
+		? Math.round(((state.currentIndex + 1) / state.filage.lectures.length) * 100)
+		: 0,
+	completed: state.completedToday
+});
+
+const isEmpty = $derived(
+	state.filage !== null && state.filage.lectures.length === 0 && !state.loading
+);
+
+const pendingQuestionsCount = $derived(
+	state.filage?.notes_with_questions ?? state.pendingQuestions.length
+);
+
+// Group lectures by reason category
+const lecturesByCategory = $derived.by(() => {
+	if (!state.filage) return {};
+
+	const groups: Record<string, FilageLecture[]> = {
+		questions_pending: [],
+		event_related: [],
+		sm2_due: [],
+		recently_improved: []
+	};
+
+	for (const lecture of state.filage.lectures) {
+		if (lecture.questions_pending) {
+			groups.questions_pending.push(lecture);
+		} else if (lecture.related_event_id) {
+			groups.event_related.push(lecture);
+		} else if (lecture.reason.includes('SM-2') || lecture.reason.includes('révision')) {
+			groups.sm2_due.push(lecture);
+		} else if (lecture.reason.includes('Améliorée') || lecture.reason.includes('✨')) {
+			groups.recently_improved.push(lecture);
+		} else {
+			// Default to SM-2 due
+			groups.sm2_due.push(lecture);
+		}
+	}
+
+	return groups;
+});
+
+// ============================================================================
+// ACTIONS
+// ============================================================================
+
+async function fetchFilage(maxLectures = 20): Promise<void> {
+	state.loading = true;
+	state.error = null;
+
+	try {
+		state.filage = await apiGetFilage(maxLectures);
+		state.currentIndex = 0;
+		state.lastFetch = new Date();
+	} catch (err) {
+		handleError(err, 'Impossible de charger le filage');
+	} finally {
+		state.loading = false;
+	}
+}
+
+async function startSession(noteId: string): Promise<LectureSession | null> {
+	state.loading = true;
+	state.error = null;
+
+	try {
+		state.currentSession = await apiStartLecture(noteId);
+		return state.currentSession;
+	} catch (err) {
+		handleError(err, 'Impossible de démarrer la session');
+		return null;
+	} finally {
+		state.loading = false;
+	}
+}
+
+async function completeSession(
+	quality: number,
+	answers?: Record<string, string>
+): Promise<LectureResult | null> {
+	if (!state.currentSession) return null;
+
+	state.loading = true;
+	state.error = null;
+
+	try {
+		const result = await apiCompleteLecture(
+			state.currentSession.note_id,
+			quality,
+			answers
+		);
+
+		if (result.success) {
+			// Remove completed lecture from filage
+			if (state.filage) {
+				state.filage = {
+					...state.filage,
+					lectures: state.filage.lectures.filter(
+						(l) => l.note_id !== state.currentSession?.note_id
+					),
+					total_lectures: state.filage.total_lectures - 1
+				};
+			}
+
+			state.completedToday++;
+			state.currentSession = null;
+
+			// Adjust index if needed
+			if (state.filage && state.currentIndex >= state.filage.lectures.length) {
+				state.currentIndex = Math.max(0, state.filage.lectures.length - 1);
+			}
+		}
+
+		return result;
+	} catch (err) {
+		handleError(err, 'Impossible de terminer la session');
+		return null;
+	} finally {
+		state.loading = false;
+	}
+}
+
+function nextLecture(): void {
+	if (hasNext) {
+		state.currentIndex++;
+		state.currentSession = null;
+	}
+}
+
+function previousLecture(): void {
+	if (hasPrevious) {
+		state.currentIndex--;
+		state.currentSession = null;
+	}
+}
+
+function skipLecture(): void {
+	// Move to next without starting session
+	if (hasNext) {
+		state.currentIndex++;
+	}
+	state.currentSession = null;
+}
+
+function goToLecture(index: number): void {
+	if (state.filage && index >= 0 && index < state.filage.lectures.length) {
+		state.currentIndex = index;
+		state.currentSession = null;
+	}
+}
+
+function resetSession(): void {
+	state.currentIndex = 0;
+	state.currentSession = null;
+	state.completedToday = 0;
+}
+
+function clearError(): void {
+	state.error = null;
+}
+
+// Questions management
+async function fetchPendingQuestions(limit = 50): Promise<void> {
+	state.questionsLoading = true;
+
+	try {
+		const response = await apiGetPendingQuestions(limit);
+		state.pendingQuestions = response.questions;
+	} catch (err) {
+		console.error('Failed to fetch pending questions:', err);
+	} finally {
+		state.questionsLoading = false;
+	}
+}
+
+async function answerQuestion(
+	questionId: string,
+	answer: string
+): Promise<boolean> {
+	try {
+		await apiAnswerQuestion(questionId, answer);
+		// Remove answered question from list
+		state.pendingQuestions = state.pendingQuestions.filter(
+			(q) => q.question_id !== questionId
+		);
+		return true;
+	} catch (err) {
+		console.error('Failed to answer question:', err);
+		return false;
+	}
+}
+
+// ============================================================================
+// ERROR HANDLING
+// ============================================================================
+
+function handleError(err: unknown, defaultMessage: string): void {
+	if (err instanceof ApiError) {
+		if (err.status === 0) {
+			state.error = 'Impossible de contacter le serveur. Vérifiez votre connexion.';
+		} else {
+			state.error = `Erreur ${err.status}: ${err.message}`;
+		}
+	} else {
+		state.error = defaultMessage;
+	}
+	console.error(defaultMessage, err);
+}
+
+// ============================================================================
+// EXPORT STORE
+// ============================================================================
+
+export const memoryCyclesStore = {
+	// State getters
+	get state() {
+		return state;
+	},
+	get filage() {
+		return state.filage;
+	},
+	get currentSession() {
+		return state.currentSession;
+	},
+	get loading() {
+		return state.loading;
+	},
+	get error() {
+		return state.error;
+	},
+	get lastFetch() {
+		return state.lastFetch;
+	},
+	get pendingQuestions() {
+		return state.pendingQuestions;
+	},
+	get questionsLoading() {
+		return state.questionsLoading;
+	},
+
+	// Derived getters
+	get currentLecture() {
+		return currentLecture;
+	},
+	get currentIndex() {
+		return state.currentIndex;
+	},
+	get hasNext() {
+		return hasNext;
+	},
+	get hasPrevious() {
+		return hasPrevious;
+	},
+	get totalLectures() {
+		return totalLectures;
+	},
+	get progress() {
+		return progress;
+	},
+	get isEmpty() {
+		return isEmpty;
+	},
+	get pendingQuestionsCount() {
+		return pendingQuestionsCount;
+	},
+	get completedToday() {
+		return state.completedToday;
+	},
+	get lecturesByCategory() {
+		return lecturesByCategory;
+	},
+
+	// Actions
+	fetchFilage,
+	startSession,
+	completeSession,
+	nextLecture,
+	previousLecture,
+	skipLecture,
+	goToLecture,
+	resetSession,
+	clearError,
+	fetchPendingQuestions,
+	answerQuestion
+};
+
+export type {
+	Filage,
+	FilageLecture,
+	LectureSession,
+	LectureResult,
+	PendingQuestion
+};

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -7,6 +7,8 @@
 	import { formatRelativeTime } from '$lib/utils/formatters';
 	import { briefingStore } from '$lib/stores';
 	import { notesReviewStore } from '$lib/stores/notes-review.svelte';
+	import { memoryCyclesStore } from '$lib/stores/memory-cycles.svelte';
+	import FilageWidget from '$lib/components/memory/FilageWidget.svelte';
 	import type { ScapinEvent } from '$lib/types';
 
 	// Mock data for development (fallback when API unavailable)
@@ -82,7 +84,11 @@
 
 	// Load data on mount
 	onMount(async () => {
-		await Promise.all([loadBriefingData(), notesReviewStore.fetchStats()]);
+		await Promise.all([
+			loadBriefingData(),
+			notesReviewStore.fetchStats(),
+			memoryCyclesStore.fetchFilage(20)
+		]);
 	});
 
 	async function loadBriefingData(): Promise<void> {
@@ -247,6 +253,16 @@
 			</Card>
 		</section>
 
+		<!-- Filage Widget (Memory Cycles) -->
+		{#if memoryCyclesStore.filage && memoryCyclesStore.totalLectures > 0}
+			<FilageWidget
+				totalLectures={memoryCyclesStore.totalLectures}
+				completedToday={memoryCyclesStore.completedToday}
+				questionsCount={memoryCyclesStore.pendingQuestionsCount}
+				loading={memoryCyclesStore.loading}
+			/>
+		{/if}
+
 		<!-- Notes Review Widget -->
 		{#if notesReviewStore.stats && notesReviewStore.stats.total_due > 0}
 			<section class="mb-5" data-testid="notes-review-widget">
@@ -255,7 +271,7 @@
 				>
 					<span>📝</span> Notes à réviser
 				</h2>
-				<Card interactive onclick={() => goto('/notes/review')}>
+				<Card interactive onclick={() => goto('/memoires/review')}>
 					<div class="flex items-center justify-between p-3">
 						<div>
 							<p class="text-lg font-semibold text-[var(--color-text-primary)]">

--- a/web/src/routes/memoires/filage/+page.svelte
+++ b/web/src/routes/memoires/filage/+page.svelte
@@ -1,0 +1,358 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { memoryCyclesStore } from '$lib/stores/memory-cycles.svelte';
+	import FilageProgressHeader from '$lib/components/memory/FilageProgressHeader.svelte';
+	import FilageSection from '$lib/components/memory/FilageSection.svelte';
+	import FilageLectureCard from '$lib/components/memory/FilageLectureCard.svelte';
+	import LectureReviewCard from '$lib/components/memory/LectureReviewCard.svelte';
+	import QualityRating from '$lib/components/notes/QualityRating.svelte';
+	import { Card, PullToRefresh } from '$lib/components/ui';
+	import { REASON_ICONS, REASON_LABELS } from '$lib/api/types/memory-cycles';
+
+	// Session mode: list or review
+	let mode = $state<'list' | 'review'>('list');
+	let lastResult = $state<{ quality: number; message: string } | null>(null);
+	let questionAnswers = $state<Record<string, string>>({});
+
+	onMount(async () => {
+		await memoryCyclesStore.fetchFilage(20);
+	});
+
+	// Format date for display
+	function formatDate(dateStr: string): string {
+		const date = new Date(dateStr);
+		return date.toLocaleDateString('fr-FR', {
+			weekday: 'long',
+			day: 'numeric',
+			month: 'long'
+		});
+	}
+
+	// Get today's date formatted
+	const todayFormatted = $derived(
+		memoryCyclesStore.filage
+			? formatDate(memoryCyclesStore.filage.date)
+			: formatDate(new Date().toISOString())
+	);
+
+	// Actions
+	async function handleRefresh() {
+		await memoryCyclesStore.fetchFilage(20);
+	}
+
+	async function handleStartSession() {
+		const lecture = memoryCyclesStore.currentLecture;
+		if (!lecture) return;
+
+		const session = await memoryCyclesStore.startSession(lecture.note_id);
+		if (session) {
+			mode = 'review';
+		}
+	}
+
+	async function handleRate(quality: number) {
+		const result = await memoryCyclesStore.completeSession(quality, questionAnswers);
+		if (result) {
+			lastResult = {
+				quality: result.quality_rating,
+				message: result.success ? 'Lecture terminée' : 'Erreur'
+			};
+			questionAnswers = {};
+
+			// Return to list mode if done, or show next
+			if (memoryCyclesStore.isEmpty) {
+				mode = 'list';
+			} else if (!memoryCyclesStore.hasNext) {
+				mode = 'list';
+			}
+
+			// Clear result after 2s
+			setTimeout(() => {
+				lastResult = null;
+			}, 2000);
+		}
+	}
+
+	function handleSelectLecture(index: number) {
+		memoryCyclesStore.goToLecture(index);
+	}
+
+	function handleBack() {
+		if (mode === 'review') {
+			mode = 'list';
+		} else {
+			goto('/memoires');
+		}
+	}
+
+	function handleAnswerQuestions(answers: Record<string, string>) {
+		questionAnswers = answers;
+	}
+
+	// Grouped lectures
+	const lecturesByCategory = $derived(memoryCyclesStore.lecturesByCategory);
+</script>
+
+<svelte:head>
+	<title>Filage - Scapin</title>
+</svelte:head>
+
+<div class="min-h-screen bg-[var(--color-bg-primary)]">
+	<FilageProgressHeader
+		title="Filage du {todayFormatted}"
+		current={memoryCyclesStore.completedToday}
+		total={memoryCyclesStore.totalLectures}
+		onBack={handleBack}
+		onRefresh={handleRefresh}
+		loading={memoryCyclesStore.loading}
+	/>
+
+	<PullToRefresh onrefresh={handleRefresh}>
+		<main class="max-w-2xl mx-auto px-4 py-6">
+			<!-- Loading State -->
+			{#if memoryCyclesStore.loading && !memoryCyclesStore.filage}
+				<div class="flex flex-col items-center justify-center py-20">
+					<div
+						class="w-10 h-10 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin mb-4"
+					></div>
+					<p class="text-[var(--color-text-secondary)]">Chargement du filage...</p>
+				</div>
+
+			<!-- Empty State -->
+			{:else if memoryCyclesStore.isEmpty}
+				<div class="flex flex-col items-center justify-center py-20 text-center">
+					<p class="text-5xl mb-4">🎉</p>
+					<h2 class="text-xl font-semibold text-[var(--color-text-primary)] mb-2">
+						Aucune lecture aujourd'hui
+					</h2>
+					<p class="text-[var(--color-text-secondary)] mb-6">
+						Votre mémoire est à jour. Revenez demain !
+					</p>
+					<button
+						type="button"
+						onclick={() => goto('/memoires')}
+						class="px-4 py-2 bg-[var(--color-accent)] text-white rounded-xl hover:bg-[var(--color-accent)]/90 transition-colors liquid-press"
+					>
+						Retour aux mémoires
+					</button>
+				</div>
+
+			<!-- Review Mode -->
+			{:else if mode === 'review' && memoryCyclesStore.currentSession}
+				<div class="space-y-6">
+					<!-- Lecture card -->
+					<LectureReviewCard
+						session={memoryCyclesStore.currentSession}
+						recentlyImproved={memoryCyclesStore.currentLecture?.reason.includes('Améliorée')}
+						onViewNote={() => goto(`/memoires/${encodeURIComponent(memoryCyclesStore.currentSession?.note_id ?? '')}`)}
+						onAnswerQuestions={handleAnswerQuestions}
+					/>
+
+					<!-- Success feedback -->
+					{#if lastResult}
+						<div
+							class="p-3 bg-green-500/10 rounded-xl border border-green-500/30 text-center animate-fade-in"
+						>
+							<p class="text-sm text-green-600 dark:text-green-400">
+								{lastResult.message}
+							</p>
+						</div>
+					{/if}
+
+					<!-- Quality Rating -->
+					<Card variant="glass">
+						<QualityRating onRate={handleRate} disabled={memoryCyclesStore.loading} />
+					</Card>
+
+					<!-- Navigation -->
+					<div class="flex items-center justify-between">
+						<button
+							type="button"
+							onclick={() => { mode = 'list'; }}
+							class="px-4 py-2 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+						>
+							← Retour à la liste
+						</button>
+
+						<div class="flex gap-2">
+							{#if memoryCyclesStore.hasPrevious}
+								<button
+									type="button"
+									onclick={() => { memoryCyclesStore.previousLecture(); handleStartSession(); }}
+									class="px-3 py-2 text-sm border border-[var(--glass-border-subtle)] rounded-xl hover:bg-[var(--glass-subtle)] transition-colors liquid-press"
+								>
+									← Précédent
+								</button>
+							{/if}
+							{#if memoryCyclesStore.hasNext}
+								<button
+									type="button"
+									onclick={() => { memoryCyclesStore.skipLecture(); handleStartSession(); }}
+									class="px-3 py-2 text-sm border border-[var(--glass-border-subtle)] rounded-xl hover:bg-[var(--glass-subtle)] transition-colors liquid-press"
+								>
+									Passer →
+								</button>
+							{/if}
+						</div>
+					</div>
+
+					<!-- Keyboard shortcuts hint -->
+					<p class="text-xs text-[var(--color-text-tertiary)] text-center">
+						Raccourcis : 1-6 noter | ← → naviguer | Esc liste
+					</p>
+				</div>
+
+			<!-- List Mode -->
+			{:else if memoryCyclesStore.filage}
+				<div class="space-y-4">
+					<!-- Summary stats -->
+					<div class="grid grid-cols-3 gap-2 mb-4">
+						<Card padding="sm">
+							<div class="text-center">
+								<p class="text-2xl font-bold text-[var(--color-accent)]">
+									{memoryCyclesStore.filage.total_lectures}
+								</p>
+								<p class="text-xs text-[var(--color-text-tertiary)]">Lectures</p>
+							</div>
+						</Card>
+						<Card padding="sm">
+							<div class="text-center">
+								<p class="text-2xl font-bold text-[var(--color-event-calendar)]">
+									{memoryCyclesStore.filage.events_today}
+								</p>
+								<p class="text-xs text-[var(--color-text-tertiary)]">Événements</p>
+							</div>
+						</Card>
+						<Card padding="sm">
+							<div class="text-center">
+								<p class="text-2xl font-bold text-[var(--color-warning)]">
+									{memoryCyclesStore.filage.notes_with_questions}
+								</p>
+								<p class="text-xs text-[var(--color-text-tertiary)]">Questions</p>
+							</div>
+						</Card>
+					</div>
+
+					<!-- Sections grouped by category -->
+					{#if lecturesByCategory.questions_pending?.length > 0}
+						<FilageSection
+							title={REASON_LABELS.questions_pending}
+							icon={REASON_ICONS.questions_pending}
+							count={lecturesByCategory.questions_pending.length}
+						>
+							{#each lecturesByCategory.questions_pending as lecture, i}
+								{@const globalIndex = memoryCyclesStore.filage?.lectures.findIndex(l => l.note_id === lecture.note_id) ?? 0}
+								<FilageLectureCard
+									{lecture}
+									selected={memoryCyclesStore.currentIndex === globalIndex}
+									onclick={() => handleSelectLecture(globalIndex)}
+								/>
+							{/each}
+						</FilageSection>
+					{/if}
+
+					{#if lecturesByCategory.event_related?.length > 0}
+						<FilageSection
+							title={REASON_LABELS.event_related}
+							icon={REASON_ICONS.event_related}
+							count={lecturesByCategory.event_related.length}
+						>
+							{#each lecturesByCategory.event_related as lecture}
+								{@const globalIndex = memoryCyclesStore.filage?.lectures.findIndex(l => l.note_id === lecture.note_id) ?? 0}
+								<FilageLectureCard
+									{lecture}
+									selected={memoryCyclesStore.currentIndex === globalIndex}
+									onclick={() => handleSelectLecture(globalIndex)}
+								/>
+							{/each}
+						</FilageSection>
+					{/if}
+
+					{#if lecturesByCategory.sm2_due?.length > 0}
+						<FilageSection
+							title={REASON_LABELS.sm2_due}
+							icon={REASON_ICONS.sm2_due}
+							count={lecturesByCategory.sm2_due.length}
+						>
+							{#each lecturesByCategory.sm2_due as lecture}
+								{@const globalIndex = memoryCyclesStore.filage?.lectures.findIndex(l => l.note_id === lecture.note_id) ?? 0}
+								<FilageLectureCard
+									{lecture}
+									selected={memoryCyclesStore.currentIndex === globalIndex}
+									onclick={() => handleSelectLecture(globalIndex)}
+								/>
+							{/each}
+						</FilageSection>
+					{/if}
+
+					{#if lecturesByCategory.recently_improved?.length > 0}
+						<FilageSection
+							title={REASON_LABELS.recently_improved}
+							icon={REASON_ICONS.recently_improved}
+							count={lecturesByCategory.recently_improved.length}
+						>
+							{#each lecturesByCategory.recently_improved as lecture}
+								{@const globalIndex = memoryCyclesStore.filage?.lectures.findIndex(l => l.note_id === lecture.note_id) ?? 0}
+								<FilageLectureCard
+									{lecture}
+									selected={memoryCyclesStore.currentIndex === globalIndex}
+									onclick={() => handleSelectLecture(globalIndex)}
+								/>
+							{/each}
+						</FilageSection>
+					{/if}
+
+					<!-- Start session button -->
+					<div class="sticky bottom-4 pt-4">
+						<button
+							type="button"
+							onclick={handleStartSession}
+							disabled={memoryCyclesStore.loading || !memoryCyclesStore.currentLecture}
+							class="w-full py-3 bg-[var(--color-accent)] text-white rounded-xl font-medium
+								hover:bg-[var(--color-accent)]/90 transition-colors disabled:opacity-50
+								shadow-lg liquid-press"
+						>
+							{#if memoryCyclesStore.currentLecture}
+								Commencer avec "{memoryCyclesStore.currentLecture.note_title}"
+							{:else}
+								Sélectionnez une lecture
+							{/if}
+						</button>
+					</div>
+				</div>
+			{/if}
+
+			<!-- Error State -->
+			{#if memoryCyclesStore.error}
+				<div class="mt-4 p-4 bg-red-500/10 rounded-xl border border-red-500/30">
+					<p class="text-sm text-red-600 dark:text-red-400">{memoryCyclesStore.error}</p>
+					<button
+						type="button"
+						onclick={() => memoryCyclesStore.clearError()}
+						class="mt-2 text-xs text-red-500 underline"
+					>
+						Fermer
+					</button>
+				</div>
+			{/if}
+		</main>
+	</PullToRefresh>
+</div>
+
+<style>
+	@keyframes fade-in {
+		from {
+			opacity: 0;
+			transform: translateY(-4px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	.animate-fade-in {
+		animation: fade-in 0.2s ease-out;
+	}
+</style>

--- a/web/src/routes/memoires/questions/+page.svelte
+++ b/web/src/routes/memoires/questions/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { memoryCyclesStore } from '$lib/stores/memory-cycles.svelte';
+	import QuestionsGroupedList from '$lib/components/memory/QuestionsGroupedList.svelte';
+	import { Card, PullToRefresh, Tabs } from '$lib/components/ui';
+
+	// Tab state
+	let activeTab = $state<'all' | 'by_note' | 'resolved'>('all');
+
+	// Filtered questions based on tab
+	const filteredQuestions = $derived.by(() => {
+		const questions = memoryCyclesStore.pendingQuestions;
+
+		switch (activeTab) {
+			case 'resolved':
+				return questions.filter((q) => q.answered);
+			case 'by_note':
+			case 'all':
+			default:
+				return questions.filter((q) => !q.answered);
+		}
+	});
+
+	const groupByNote = $derived(activeTab === 'by_note');
+
+	onMount(async () => {
+		await memoryCyclesStore.fetchPendingQuestions(100);
+	});
+
+	async function handleRefresh() {
+		await memoryCyclesStore.fetchPendingQuestions(100);
+	}
+
+	async function handleAnswer(questionId: string, answer: string) {
+		await memoryCyclesStore.answerQuestion(questionId, answer);
+	}
+
+	function handleSkip(questionId: string) {
+		// Skip just moves to next, no API call needed
+		console.log('Skipped question:', questionId);
+	}
+
+	// Tab definitions - counts are computed dynamically in the template
+	const tabDefs = [
+		{ id: 'all' as const, label: 'Toutes' },
+		{ id: 'by_note' as const, label: 'Par note' },
+		{ id: 'resolved' as const, label: 'Résolues' }
+	];
+
+	const resolvedCount = $derived(
+		memoryCyclesStore.pendingQuestions.filter((q) => q.answered).length
+	);
+
+	const pendingCount = $derived(
+		memoryCyclesStore.pendingQuestions.filter((q) => !q.answered).length
+	);
+</script>
+
+<svelte:head>
+	<title>Questions - Scapin</title>
+</svelte:head>
+
+<div class="min-h-screen bg-[var(--color-bg-primary)]">
+	<!-- Header -->
+	<header
+		class="sticky top-0 z-10 bg-[var(--color-bg-primary)]/80 backdrop-blur-md border-b border-[var(--glass-border-subtle)]"
+	>
+		<div class="max-w-2xl mx-auto px-4 py-3">
+			<div class="flex items-center justify-between mb-3">
+				<button
+					type="button"
+					onclick={() => goto('/memoires')}
+					class="flex items-center gap-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors liquid-press"
+				>
+					<span>←</span>
+					<span class="text-sm">Retour</span>
+				</button>
+
+				<h1 class="text-base font-semibold text-[var(--color-text-primary)]">
+					Questions
+				</h1>
+
+				<button
+					type="button"
+					onclick={handleRefresh}
+					disabled={memoryCyclesStore.questionsLoading}
+					class="p-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors liquid-press disabled:opacity-50"
+					aria-label="Rafraîchir"
+				>
+					<span class={memoryCyclesStore.questionsLoading ? 'animate-spin inline-block' : ''}>⟳</span>
+				</button>
+			</div>
+
+			<!-- Tabs -->
+			<div class="flex gap-1 p-1 bg-[var(--glass-subtle)] rounded-xl">
+				{#each tabDefs as tab}
+					{@const count = tab.id === 'resolved' ? resolvedCount : filteredQuestions.length}
+					<button
+						type="button"
+						onclick={() => activeTab = tab.id}
+						class="flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-all
+							{activeTab === tab.id
+								? 'bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] shadow-sm'
+								: 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'}"
+					>
+						{tab.label}
+						{#if count > 0}
+							<span class="ml-1 text-xs px-1.5 py-0.5 rounded-full
+								{activeTab === tab.id
+									? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
+									: 'bg-[var(--glass-subtle)] text-[var(--color-text-tertiary)]'}">
+								{count}
+							</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+	</header>
+
+	<PullToRefresh onrefresh={handleRefresh}>
+		<main class="max-w-2xl mx-auto px-4 py-6">
+			<!-- Loading State -->
+			{#if memoryCyclesStore.questionsLoading && memoryCyclesStore.pendingQuestions.length === 0}
+				<div class="flex flex-col items-center justify-center py-20">
+					<div
+						class="w-10 h-10 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin mb-4"
+					></div>
+					<p class="text-[var(--color-text-secondary)]">Chargement des questions...</p>
+				</div>
+
+			<!-- Summary stats -->
+			{:else if pendingCount > 0 && activeTab !== 'resolved'}
+				<Card variant="glass-subtle" class="mb-4" padding="sm">
+					<div class="flex items-center justify-between">
+						<div class="flex items-center gap-2">
+							<span class="text-lg">❓</span>
+							<span class="text-sm text-[var(--color-text-secondary)]">
+								{pendingCount} question{pendingCount > 1 ? 's' : ''} en attente
+							</span>
+						</div>
+						<span class="text-xs text-[var(--color-text-tertiary)]">
+							Répondez pour enrichir vos notes
+						</span>
+					</div>
+				</Card>
+			{/if}
+
+			<!-- Questions list -->
+			<QuestionsGroupedList
+				questions={filteredQuestions}
+				{groupByNote}
+				onAnswer={handleAnswer}
+				onSkip={handleSkip}
+				disabled={memoryCyclesStore.questionsLoading}
+			/>
+		</main>
+	</PullToRefresh>
+</div>


### PR DESCRIPTION
Add complete frontend implementation for Memory Cycles feature:

Types & API:
- Add memory-cycles.ts types (Filage, Lecture, Questions, Retouche)
- Add API functions to client.ts (getFilage, startLecture, completeLecture)

Stores:
- Add memory-cycles.svelte.ts store for Filage/Lecture state management
- Add gamification.svelte.ts store for streaks, badges, and XP tracking

Components (web/src/lib/components/memory/):
- FilageLectureCard: Card with icon, badges, quality bar
- FilageProgressHeader: Sticky header with progress
- FilageSection: Collapsible grouped section
- FilageWidget: Compact dashboard widget
- QualityScoreDisplay: ProgressRing with quality label
- QuestionsForm: Answer questions during review
- LectureReviewCard: Enhanced review card
- QuestionCard: Individual question card
- QuestionsGroupedList: Questions grouped by note
- RetoucheTimeline: AI improvement history timeline
- StreakDisplay: Animated flame + 7-day heatmap
- MemoryCyclesNotificationHandler: WebSocket to Toast handler

Pages:
- /memoires/filage: Morning briefing with prioritized lectures
- /memoires/questions: Questions manager with tabs

Dashboard integration:
- Add FilageWidget to homepage
- Add pending questions badge to Sidebar navigation